### PR TITLE
Add System Tray Controller, seconds precision, and updated documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ bin/
 obj/
 .vs
 _ReSharper.Caches
+Build/
+CompleteApp/
+*.user
+*.suo
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,7 @@ bin/
 obj/
 .vs
 _ReSharper.Caches
-Build/
-CompleteApp/
 *.user
 *.suo
 *.log
+*.csv

--- a/README.md
+++ b/README.md
@@ -54,10 +54,17 @@ dotnet run
 Navigate to the Tray application's output directory and launch the executable.
 
 ```powershell
-cd WindowLoggerTray/bin/Debug/net9.0-windows
+cd WindowLoggerTray/bin/Debug/net10.0-windows
 .\WindowLoggerTray.exe
 ```
 *(Note: The path might vary slightly depending on your configuration, e.g., Release mode)*
+
+Or from the project directory:
+
+```bash
+cd WindowLoggerTray
+dotnet run
+```
 
 **What happens:**
 - An icon appears in your System Tray (near the clock).

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ Group applications into higher-level categories for aggregate reporting.
 
 ---
 
-## 🛠️ Troubleshooting
+## Troubleshooting
 
 ### "Error reading appsettings.json"
 
@@ -640,6 +640,6 @@ Group applications into higher-level categories for aggregate reporting.
 
 ---
 
-## 📄 License
+## License
 
 This project is open source and available under the repository license.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Window Logger is a productivity tracking tool that monitors active windows and a
 
 The system runs discretely in the system tray and consists of four components:
 
-1. **WindowLoggerTray** (Controller) - A system tray app that manages the background logger and provides quick access to actions.
 2. **WindowLogger** - A background process that monitors and logs active windows.
-3. **WindowAnalyser** - Analyzes logs and generates detailed Excel reports.
+3. **WindowLoggerTray** (Controller) - A system tray app that manages the background logger and provides quick access to actions.
 4. **WindowLoggerConfigGui** - A visual editor for configuration rules.
+5. **WindowAnalyser** - Analyzes logs and generates detailed Excel reports.
+
 
 ---
 
@@ -50,30 +51,33 @@ dotnet run
 
 ### Step 3: Run the Controller
 
-Navigate to the created folder and start the tray application using the dotnet runtime:
+Navigate to the Tray application's output directory and launch the executable.
 
-```bash
-cd App
-dotnet WindowLoggerTray.dll
+```powershell
+cd WindowLoggerTray/bin/Debug/net9.0-windows
+.\WindowLoggerTray.exe
 ```
+*(Note: The path might vary slightly depending on your configuration, e.g., Release mode)*
 
 **What happens:**
 - An icon appears in your System Tray (near the clock).
 - Right-click the icon to control the application.
 
+---
+
 ## Using the Controller
 
-Once WindowLoggerTray is running, right-click the tray icon to access the menu:
+Once **WindowLoggerTray** is running, right-click the tray icon to access the menu:
 
-- **Start Logging**: Launches WindowLogger.dll in the background (hidden).
+- **Start Logging**: Launches `WindowLogger.exe` in the background (hidden).
 - **Stop Logging**: Safely stops the background logger process.
-- **Generate Report & Open**: Runs analysis on collected data and opens the Excel report automatically.
+- **Generate Report & Open**: Runs analysis and opens the Excel report automatically.
 - **Edit Configuration**:
-    - **GUI**: Opens the visual editor (WindowLoggerConfigGui.dll).
-    - **JSON**: Opens the raw appsettings.json file.
+    - **GUI**: Opens the visual editor (`WindowLoggerConfigGui.exe`).
+    - **JSON**: Opens the raw `appsettings.json` file.
 - **Clear Collected Data**: Deletes the current log file to start fresh.
 
-### Step 3: Analyze the Data
+### Step 4: Analyze the Data
 
 Navigate to the WindowAnalyser output directory and run:
 
@@ -109,6 +113,12 @@ dotnet run -- ../../WindowLogger/bin/Debug/net9.0/WindowLogger.csv weekly_report
 
 - **File Name:** appsettings.json
 - **Location:** Created in the same directory. Defines how windows are grouped into Applications and Categories.
+
+### Report.xslx
+
+WindowLoggerTray generates **Report.xslx** file when you use the `Generate Report Open` option. It uses data from the **WindowLogger.csv** file.
+
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ dotnet run -- <path-to-csv> <output-xlsx-path>
 dotnet run -- ../../WindowLogger/bin/Debug/net9.0/WindowLogger.csv weekly_report.xlsx
 ```
 
+### Alternatively - Use the Controller Application
+
+You can generate the `Report.xslx` directly from the **WindowLoggerTray** by clicking "Generate Report & Open".
+
 ---
 
 ## Data Storage

--- a/README.md
+++ b/README.md
@@ -125,6 +125,41 @@ dotnet WindowLogger.dll
 ```bash
 dotnet WindowAnalyser.dll WindowLogger.csv Report.xlsx
 ```
+### Log File Format
+
+The CSV file contains three columns:
+
+```text
+Timestamp,Window Title [Executable],Status
+```
+
+**Example Content:**
+
+```csv
+2026-01-18 09:15:30,Visual Studio 2022 [devenv.exe],Active
+2026-01-18 09:20:45,Google Chrome - GitHub [chrome.exe],Active
+2026-01-18 09:25:10,Slack - Development Team [slack.exe],Active
+2026-01-18 09:30:00,Slack - Development Team [slack.exe],Inactive
+2026-01-18 09:31:15,Visual Studio 2022 [devenv.exe],Active
+```
+
+**Status Values:**
+
+- `Active` - User is actively using the computer
+- `Inactive` - No user input detected for 1+ minute (configurable)
+
+### Configuration File Location
+
+**File Name:** `appsettings.json`  
+**Location:** Same directory as `WindowAnalyser.exe`
+
+The configuration file must be in:
+
+```test
+WindowAnalyser/bin/Debug/net9.0/appsettings.json
+```
+
+The project is already configured to copy this file to the output directory automatically.
 
 ---
 
@@ -138,33 +173,359 @@ The generated Excel workbook contains 4 worksheets:
 4. **Windows**: Daily breakdown of all raw window activity.
 
 **Time Columns:** The report includes precise time tracking:
-Time Spent (Hours) | Time Spent (Minutes) | Time Spent (Seconds)
+Time Spent (Hours) | Time Spent (Minutes)
 
 ---
 
-## Configuration (appsettings.json)
+## WindowLogger - Data Collection
 
-The configuration file controls how window titles are classified.
+### Features
 
-### Structure Example
+- **Real-time Window Tracking**: Monitors the foreground window every 100ms
+- **Executable Detection**: Records both window title and process name
+- **Inactivity Detection**: Automatically detects when user is idle (default: 1 minute)
+- **Continuous Logging**: Appends to CSV file - safe to stop/restart
+
+### How It Works
+
+1. Polls the foreground window every 100 milliseconds
+2. Detects window changes and logs them with timestamp
+3. Monitors user input (keyboard/mouse) to detect inactivity
+4. When inactive for 1 minute, logs "Inactive" status
+5. When activity resumes, logs "Active" status with new window
+
+### Customization
+
+Edit constants in `WindowLogger/Program.cs`:
+
+```csharp
+private const double MinutesToInactive = 1;  // Inactivity threshold in minutes
+```
+
+Change timer interval (default: 100ms):
+
+```csharp
+_timer = new Timer(100);  // Polling interval in milliseconds
+```
+
+### Running as a Background Service
+
+**Option 1: Start Minimized**
+
+- Create a shortcut to `WindowLogger.exe`
+- Right-click → Properties → Run: Minimized
+
+**Option 2: Windows Task Scheduler**
+
+- Schedule to run at login
+- Run whether user is logged on or not
+- Configure to restart on failure
+
+---
+
+## WindowAnalyser - Data Analysis
+
+### Command Line Usage
+
+```bash
+WindowAnalyser.exe <input-csv-file> <output-xlsx-file>
+```
+
+**Parameters:**
+
+- `input-csv-file` - Path to the CSV log file created by WindowLogger
+- `output-xlsx-file` - Desired path/name for the Excel report
+
+**Examples:**
+
+```bash
+# Absolute paths
+WindowAnalyser.exe C:\Logs\window_log.csv C:\Reports\weekly_report.xlsx
+
+# Relative paths
+WindowAnalyser.exe window_log.csv report.xlsx
+
+# Analyze multiple periods
+WindowAnalyser.exe logs\january.csv reports\january_analysis.xlsx
+WindowAnalyser.exe logs\february.csv reports\february_analysis.xlsx
+```
+
+### Generated Excel Report
+
+The output workbook contains **4 worksheets**:
+
+#### 1. Categories Tab
+Groups time by configured categories (e.g., "Productivity", "Development")
+
+| Category | Status | Time Spent (Minutes) | Time Spent (Hours) |
+|----------|--------|---------------------|-------------------|
+| Development | Active | 240.5 | 4.01 |
+| Communication | Active | 95.2 | 1.59 |
+| Productivity | Inactive | 15.0 | 0.25 |
+
+#### 2. Applications Tab
+Groups time by configured application names
+
+| Application | Status | Time Spent (Minutes) | Time Spent (Hours) |
+|-------------|--------|---------------------|-------------------|
+| Visual Studio | Active | 180.3 | 3.01 |
+| Browser | Active | 120.5 | 2.01 |
+| Slack | Active | 45.2 | 0.75 |
+
+#### 3. Undefined Applications Tab
+Shows windows that **didn't match** any application rule - use this to identify applications you should add to your configuration
+
+| Window | Status | Time Spent (Minutes) | Time Spent (Hours) |
+|--------|--------|---------------------|-------------------|
+| Calculator [calc.exe] | Active | 25.5 | 0.43 |
+| Notepad++ [notepad++.exe] | Active | 18.2 | 0.30 |
+
+#### 4. Windows Tab
+Daily breakdown of all window activity
+
+| Date | Window | Status | Time Spent (Minutes) | Time Spent (Hours) |
+|------|--------|--------|---------------------|-------------------|
+| 2026-01-18 | Visual Studio | Active | 120.5 | 2.01 |
+| 2026-01-18 | Chrome | Active | 65.3 | 1.09 |
+| 2026-01-19 | Visual Studio | Active | 180.0 | 3.00 |
+
+### Analysis Workflow
+
+1. **First Run** - Without `appsettings.json`
+   ```bash
+   WindowAnalyser.exe window_log.csv initial_report.xlsx
+   ```
+   - All windows appear in "Undefined Applications" tab
+   - No categories are generated
+
+2. **Review Undefined Applications**
+   - Open the Excel report
+   - Check the "Undefined Applications" tab
+   - Identify which windows you want to track
+
+3. **Configure Application Rules**
+   - Edit `appsettings.json` in the WindowAnalyser directory
+   - Add application definitions based on window titles
+   - Define categories for grouping
+
+4. **Re-run Analysis**
+   ```bash
+   WindowAnalyser.exe window_log.csv categorized_report.xlsx
+   ```
+   - Applications now appear in "Applications" tab
+   - Categories are populated
+   - "Undefined Applications" shows only unmatched windows
+
+5. **Iterate**
+   - Continue refining rules until most windows are categorized
+   - Run analysis periodically (daily/weekly) to track trends
+
+---
+
+## Configuration
+
+The `appsettings.json` file controls how window titles are classified.
+
+### Configuration File Structure
+
+```json
+{
+  "applications": [ ... ],
+  "exclusions": [ ... ],
+  "categories": [ ... ]
+}
+```
+
+### Applications Section
+
+Define how window titles map to logical application names.
+
+**Properties:**
+
+- `name` - Logical application name (appears in report)
+- `include` - Keywords that **must all** appear in the window title
+- `exclude` - Keywords that **must not** appear (optional)
+
+**Example:**
+
+```json
+{
+  "name": "Browser",
+  "include": [ "Firefox" ],
+  "exclude": [ "taskbeat" ]
+}
+```
+
+**Matching Rules:**
+
+- All `include` keywords must be present (AND logic)
+- Any `exclude` keyword disqualifies the match
+- Matching is **case-insensitive**
+- **First match wins** - order matters!
+
+**Best Practices:**
+
+1. **Specific rules first, generic rules last:**
+```json
+{
+  "applications": [
+    {
+      "name": "Notepad - MyTask",
+      "include": [ "Notepad", "MyTask.txt" ],
+      "exclude": []
+    },
+    {
+      "name": "Notepad",
+      "include": [ "Notepad" ],
+      "exclude": [ "MyTask.txt" ]
+    }
+  ]
+}
+```
+
+2. **Use executable names for precision:**
+```json
+{
+  "name": "Visual Studio",
+  "include": [ "Visual Studio", "devenv.exe" ],
+  "exclude": []
+}
+```
+
+3. **Group similar browsers:**
+```json
+[
+  {
+    "name": "Browser",
+    "include": [ "Firefox" ],
+    "exclude": []
+  },
+  {
+    "name": "Browser",
+    "include": [ "Chrome" ],
+    "exclude": []
+  },
+  {
+    "name": "Browser",
+    "include": [ "Edge" ],
+    "exclude": []
+  }
+]
+```
+
+### Exclusions Section
+
+Define window titles to **completely remove** from analysis.
+
+**Example:**
+```json
+{
+  "exclusions": [
+    {
+      "include": [ "Firefox", "ebay", "cart" ]
+    },
+    {
+      "include": [ "private", "browsing" ]
+    }
+  ]
+}
+```
+
+When a window matches an exclusion rule:
+
+- It's removed from **all** reports
+- Time is not counted anywhere
+- It's as if the window never existed
+
+**Use Cases:**
+
+- Exclude personal browsing during work hours
+- Filter out sensitive/private windows
+- Remove testing/debugging windows
+
+### Categories Section
+
+Group applications into higher-level categories for aggregate reporting.
+
+**Properties:**
+
+- `name` - Category name (appears in report)
+- `includeApplications` - Application names to include
+- `excludeApplications` - Applications to exclude (optional)
+
+**Example:**
+```json
+{
+  "categories": [
+    {
+      "name": "Development",
+      "includeApplications": [ "Visual Studio", "VS Code", "Terminal" ],
+      "excludeApplications": []
+    },
+    {
+      "name": "Productivity",
+      "includeApplications": [ "Notepad", "TaskBeat" ],
+      "excludeApplications": [ "Notepad - MyTask" ]
+    },
+    {
+      "name": "Communication",
+      "includeApplications": [ "Slack", "Teams", "Outlook" ],
+      "excludeApplications": []
+    }
+  ]
+}
+```
+
+**Important:**
+
+- Applications can belong to **multiple categories**
+- Time is counted separately for each category (can exceed 100%)
+- Use `excludeApplications` to create exceptions within broader groups
+
+### Complete Example Configuration
 
 ```json
 {
   "applications": [
     {
-      "name": "Browser",
-      "include": [ "Firefox", "Chrome", "Edge" ],
-      "exclude": [ "taskbeat" ]
+      "name": "Visual Studio",
+      "include": [ "Visual Studio" ],
+      "exclude": []
     },
     {
-      "name": "Visual Studio",
-      "include": [ "Visual Studio", "devenv.exe" ],
+      "name": "VS Code",
+      "include": [ "Visual Studio Code" ],
       "exclude": []
+    },
+    {
+      "name": "Browser",
+      "include": [ "Firefox" ],
+      "exclude": [ "taskbeat" ]
     },
     {
       "name": "TaskBeat",
       "include": [ "Firefox", "taskbeat" ],
       "exclude": []
+    },
+    {
+      "name": "Slack",
+      "include": [ "Slack" ],
+      "exclude": []
+    },
+    {
+      "name": "Notepad - MyTask",
+      "include": [ "Notepad", "MyTask.txt" ],
+      "exclude": []
+    },
+    {
+      "name": "Notepad",
+      "include": [ "Notepad" ],
+      "exclude": [ "MyTask.txt" ]
+    }
+  ],
+  "exclusions": [
+    {
+      "include": [ "Firefox", "ebay", "cart" ]
     }
   ],
   "categories": [
@@ -174,49 +535,111 @@ The configuration file controls how window titles are classified.
       "excludeApplications": []
     },
     {
+      "name": "Communication",
+      "includeApplications": [ "Slack" ],
+      "excludeApplications": []
+    },
+    {
       "name": "Productivity",
       "includeApplications": [ "Notepad", "TaskBeat" ],
-      "excludeApplications": []
-    }
-  ],
-  "exclusions": [
+      "excludeApplications": [ "Notepad - MyTask" ]
+    },
     {
-      "include": [ "private", "incognito" ]
+      "name": "MyTask",
+      "includeApplications": [ "Notepad - MyTask" ],
+      "excludeApplications": []
     }
   ]
 }
 ```
 
-### Matching Logic
-1. **Applications**: Matches if ALL include keywords are present and NONE of exclude keywords are present. Order matters (first match wins).
-2. **Categories**: Groups defined Applications together.
-3. **Exclusions**: Windows matching these rules are completely ignored (not logged in report).
-
 ---
 
 ## Requirements
 
-- **.NET Runtime**: .NET 9.0 / 10.0 or higher.
-- **Excel Viewer**: Microsoft Excel, LibreOffice, or compatible software.
+- **Operating System**: Windows (uses Win32 APIs for window tracking)
+- **.NET Runtime**: .NET 9.0 or higher
+- **Excel Viewer**: Microsoft Excel or compatible spreadsheet application
+
+### Dependencies
+
+**WindowLogger:**
+
+- No external dependencies (uses built-in Windows APIs)
+
+**WindowAnalyser:**
+
+- ClosedXML (0.105.0-rc) - for Excel generation
+- Newtonsoft.Json (13.0.3) - for configuration parsing
 
 ---
 
-## Troubleshooting
+## Tips & Best Practices
 
-### "No log file found to analyze"
-**Solution:** Start the logging via the Tray icon and wait a few seconds before generating a report.
+### Data Collection
 
-### "Report file was not created"
-**Solution:** Ensure WindowLogger.csv exists and is not open in another program (like Excel) while generating a new report.
+1. **Run Continuously**: Leave WindowLogger running all day for accurate tracking
+2. **Regular Analysis**: Analyze logs daily or weekly to identify patterns
+3. **Backup Logs**: Copy CSV files regularly - they contain your complete history
+4. **Multiple Logs**: Create separate logs for different projects or time periods by moving/renaming the CSV file
 
-### Report columns are empty
-**Solution:** Check the "Undefined Applications" tab in the Excel report to see the raw names, then update your appsettings.json to include them.
+### Configuration
+
+1. **Start Simple**: Begin with broad application categories
+2. **Refine Gradually**: Add more specific rules as you identify patterns
+3. **Use Undefined Tab**: Regularly check "Undefined Applications" to find unmatched windows
+4. **Test Rules**: Re-run analysis after configuration changes to verify rules work as expected
+5. **Document Rules**: Add comments (not supported in JSON, but keep notes separately) about why specific rules exist
+
+### Analysis
+
+1. **Compare Periods**: Generate reports for different time periods to track changes
+2. **Focus on Active Time**: Filter by "Active" status to see productive time
+3. **Review Inactive Patterns**: High inactive time may indicate distractions or away-from-desk time
+4. **Category Overlaps**: Remember that categories can overlap - total category time may exceed 100%
+
+---
+
+## 🛠️ Troubleshooting
+
+### "Error reading appsettings.json"
+
+**Cause:** Configuration file is missing or has invalid JSON  
+**Solution:**
+
+1. Ensure `appsettings.json` exists in the same directory as `WindowAnalyser.exe`
+2. Validate JSON syntax using a JSON validator
+3. The analyzer will use default settings (no grouping) if the file is invalid
+
+### "CSV format error: each row must have at least 3 columns"
+
+**Cause:** Log file is corrupted or has an unexpected format  
+**Solution:**
+
+1. Check that the CSV file was created by WindowLogger
+2. Ensure the file hasn't been manually edited with incorrect formatting
+3. Verify the file isn't empty
+
+### No data in Categories or Applications tabs
+
+**Cause:** No windows matched your application rules  
+**Solution:**
+
+1. Check the "Undefined Applications" tab to see what windows were logged
+2. Add application rules to `appsettings.json` matching those window titles
+3. Re-run the analysis
 
 ### Log file grows too large
-**Solution:** Archive old logs regularly (e.g., monthly) and use the "Clear Collected Data" option in the Tray menu to start fresh.
+
+**Cause:** Running continuously for extended periods  
+**Solution:**
+
+1. Archive old logs regularly (e.g., monthly)
+2. Analyze and move the CSV file to a different location
+3. WindowLogger will create a new `window_log.csv` automatically
 
 ---
 
-## License
+## 📄 License
 
-This project is open source.
+This project is open source and available under the repository license.

--- a/README.md
+++ b/README.md
@@ -1,290 +1,94 @@
-﻿# Window Logger
+# Window Logger
 
-Window Logger is a productivity tracking tool that monitors active windows and analyzes time spent across applications and categories. The system consists of two .NET console applications that work together to provide insights into computer usage patterns.
-
----
-
-## 🎯 Overview
-
-The system has two main components:
-
-1. **WindowLogger** - Monitors and logs active windows continuously
-2. **WindowAnalyser** - Analyzes logs and generates Excel reports
+Window Logger helps you understand how you spend time on your PC by logging the active window and producing human-friendly Excel reports. The tooling now includes a background logger, a tray app, a small GUI for configuring rules, and an analyzer that produces richer reports (including seconds).
 
 ---
 
-## 🚀 Quick Start
+## Overview
 
-### Step 1: Build the Projects
+Components:
 
-Build both applications using Visual Studio or the .NET CLI:
+- `WindowLogger` — background logger that records the active window and activity status to a CSV.
+- `WindowAnalyser` — analyzes the CSV and generates an Excel workbook report (multiple sheets).
+- `WindowLoggerTray` — lightweight tray app to start/stop the logger and access the GUI.
+- `WindowLoggerConfigGui` — small WinForms GUI to edit application/category rules.
+
+All components build from the same solution and a `CompleteApp` output folder is provided for distribution.
+
+---
+
+## Quick Start
+
+1) Build everything from the solution root:
 
 ```bash
-# From the solution directory
 dotnet build WindowLogger.sln
 ```
 
-Or build individual projects:
+2) Run the logger directly (debug build):
 
-```bash
-dotnet build WindowLogger/WindowLogger.csproj
-dotnet build WindowAnalyser/WindowAnalyser.csproj
-```
-
-### Step 2: Run the Logger
-
-Navigate to the WindowLogger output directory and run:
-
-```bash
+```powershell
 cd WindowLogger/bin/Debug/net9.0
-WindowLogger.exe
+.\WindowLogger.exe
 ```
 
-Or from the project directory:
+Or use the tray app / GUI from `CompleteApp`:
 
-```bash
-cd WindowLogger
-dotnet run
+```powershell
+cd CompleteApp
+.\WindowLoggerTray.exe    # starts tray
+.\WindowLoggerConfigGui.exe  # opens configuration GUI
 ```
 
-**What happens:**
+3) Generate a report using the analyzer (the CSV filename used by the apps is `WindowLogger.csv`):
 
-- The logger starts monitoring your active windows every 100ms
-- Console displays each window change
-- Data is saved to `window_log.csv` in the same directory as the executable
-- Press **Enter** to stop logging
-
-### Step 3: Analyze the Data
-
-Navigate to the WindowAnalyser output directory and run:
-
-```bash
-cd WindowAnalyser/bin/Debug/net9.0
-WindowAnalyser.exe window_log.csv output.xlsx
+```powershell
+dotnet run --project WindowAnalyser/WindowAnalyser.csproj -- CompleteApp/WindowLogger.csv CompleteApp/Report.xlsx
 ```
 
-Or from the project directory:
-
-```bash
-cd WindowAnalyser
-dotnet run -- <path-to-csv> <output-xlsx-path>
-```
-
-**Example:**
-
-```bash
-dotnet run -- ../../WindowLogger/bin/Debug/net9.0/window_log.csv weekly_report.xlsx
-```
+The analyzer writes `CompleteApp/Report.xlsx` — the default report filename used in packaging.
 
 ---
 
-## 📂 Data Storage
+## Data & Files
 
-### Log File Location
+- Log file: `WindowLogger.csv` (created next to the executable). Each row has:
 
-**File Name:** `window_log.csv`  
-**Location:** Same directory as `WindowLogger.exe`
+  Timestamp,Window Title [Executable],Status
 
-When running with `dotnet run`, the log file is created in:
+  Example:
 
-```csv
-WindowLogger/bin/Debug/net9.0/window_log.csv
-```
+  2026-01-18 09:15:30,Visual Studio 2022 [devenv.exe],Active
 
-When running the compiled executable directly:
-
-```csv
-<path-to-exe>/window_log.csv
-```
-
-### Log File Format
-
-The CSV file contains three columns:
-
-```text
-Timestamp,Window Title [Executable],Status
-```
-
-**Example Content:**
-
-```csv
-2026-01-18 09:15:30,Visual Studio 2022 [devenv.exe],Active
-2026-01-18 09:20:45,Google Chrome - GitHub [chrome.exe],Active
-2026-01-18 09:25:10,Slack - Development Team [slack.exe],Active
-2026-01-18 09:30:00,Slack - Development Team [slack.exe],Inactive
-2026-01-18 09:31:15,Visual Studio 2022 [devenv.exe],Active
-```
-
-**Status Values:**
-
-- `Active` - User is actively using the computer
-- `Inactive` - No user input detected for 1+ minute (configurable)
-
-### Configuration File Location
-
-**File Name:** `appsettings.json`  
-**Location:** Same directory as `WindowAnalyser.exe`
-
-The configuration file must be in:
-
-```test
-WindowAnalyser/bin/Debug/net9.0/appsettings.json
-```
-
-The project is already configured to copy this file to the output directory automatically.
+- Config: `appsettings.json` must be next to `WindowAnalyser.exe` (it is copied to output during build).
 
 ---
 
-## 📊 WindowLogger - Data Collection
+## What’s new / Notes
 
-### Features
-
-- **Real-time Window Tracking**: Monitors the foreground window every 100ms
-- **Executable Detection**: Records both window title and process name
-- **Inactivity Detection**: Automatically detects when user is idle (default: 1 minute)
-- **Continuous Logging**: Appends to CSV file - safe to stop/restart
-
-### How It Works
-
-1. Polls the foreground window every 100 milliseconds
-2. Detects window changes and logs them with timestamp
-3. Monitors user input (keyboard/mouse) to detect inactivity
-4. When inactive for 1 minute, logs "Inactive" status
-5. When activity resumes, logs "Active" status with new window
-
-### Customization
-
-Edit constants in `WindowLogger/Program.cs`:
-
-```csharp
-private const double MinutesToInactive = 1;  // Inactivity threshold in minutes
-```
-
-Change timer interval (default: 100ms):
-
-```csharp
-_timer = new Timer(100);  // Polling interval in milliseconds
-```
-
-### Running as a Background Service
-
-**Option 1: Start Minimized**
-
-- Create a shortcut to `WindowLogger.exe`
-- Right-click → Properties → Run: Minimized
-
-**Option 2: Windows Task Scheduler**
-
-- Schedule to run at login
-- Run whether user is logged on or not
-- Configure to restart on failure
+- The generated Excel report now includes a seconds column and by default orders time columns as: Hours, Minutes, Seconds — this makes totals and human-readable summaries easier to scan.
+- `CompleteApp` is a convenience output that contains all built artifacts (EXEs, DLLs, `Report.xlsx`, etc.) for distribution.
 
 ---
 
-## 📈 WindowAnalyser - Data Analysis
+## WindowAnalyser — Report Details
 
-### Command Line Usage
+The produced workbook contains these worksheets:
 
-```bash
-WindowAnalyser.exe <input-csv-file> <output-xlsx-file>
-```
+- `Categories` — aggregates by category
+- `Applications` — aggregates by application name (from your rules)
+- `Undefined Applications` — windows not matched by any rule (useful to refine rules)
+- `Windows` — daily breakdown
 
-**Parameters:**
+Time columns and ordering: Hours | Minutes | Seconds (seconds shown as an integer column).
 
-- `input-csv-file` - Path to the CSV log file created by WindowLogger
-- `output-xlsx-file` - Desired path/name for the Excel report
-
-**Examples:**
-
-```bash
-# Absolute paths
-WindowAnalyser.exe C:\Logs\window_log.csv C:\Reports\weekly_report.xlsx
-
-# Relative paths
-WindowAnalyser.exe window_log.csv report.xlsx
-
-# Analyze multiple periods
-WindowAnalyser.exe logs\january.csv reports\january_analysis.xlsx
-WindowAnalyser.exe logs\february.csv reports\february_analysis.xlsx
-```
-
-### Generated Excel Report
-
-The output workbook contains **4 worksheets**:
-
-#### 1. Categories Tab
-Groups time by configured categories (e.g., "Productivity", "Development")
-
-| Category | Status | Time Spent (Minutes) | Time Spent (Hours) |
-|----------|--------|---------------------|-------------------|
-| Development | Active | 240.5 | 4.01 |
-| Communication | Active | 95.2 | 1.59 |
-| Productivity | Inactive | 15.0 | 0.25 |
-
-#### 2. Applications Tab
-Groups time by configured application names
-
-| Application | Status | Time Spent (Minutes) | Time Spent (Hours) |
-|-------------|--------|---------------------|-------------------|
-| Visual Studio | Active | 180.3 | 3.01 |
-| Browser | Active | 120.5 | 2.01 |
-| Slack | Active | 45.2 | 0.75 |
-
-#### 3. Undefined Applications Tab
-Shows windows that **didn't match** any application rule - use this to identify applications you should add to your configuration
-
-| Window | Status | Time Spent (Minutes) | Time Spent (Hours) |
-|--------|--------|---------------------|-------------------|
-| Calculator [calc.exe] | Active | 25.5 | 0.43 |
-| Notepad++ [notepad++.exe] | Active | 18.2 | 0.30 |
-
-#### 4. Windows Tab
-Daily breakdown of all window activity
-
-| Date | Window | Status | Time Spent (Minutes) | Time Spent (Hours) |
-|------|--------|--------|---------------------|-------------------|
-| 2026-01-18 | Visual Studio | Active | 120.5 | 2.01 |
-| 2026-01-18 | Chrome | Active | 65.3 | 1.09 |
-| 2026-01-19 | Visual Studio | Active | 180.0 | 3.00 |
-
-### Analysis Workflow
-
-1. **First Run** - Without `appsettings.json`
-   ```bash
-   WindowAnalyser.exe window_log.csv initial_report.xlsx
-   ```
-   - All windows appear in "Undefined Applications" tab
-   - No categories are generated
-
-2. **Review Undefined Applications**
-   - Open the Excel report
-   - Check the "Undefined Applications" tab
-   - Identify which windows you want to track
-
-3. **Configure Application Rules**
-   - Edit `appsettings.json` in the WindowAnalyser directory
-   - Add application definitions based on window titles
-   - Define categories for grouping
-
-4. **Re-run Analysis**
-   ```bash
-   WindowAnalyser.exe window_log.csv categorized_report.xlsx
-   ```
-   - Applications now appear in "Applications" tab
-   - Categories are populated
-   - "Undefined Applications" shows only unmatched windows
-
-5. **Iterate**
-   - Continue refining rules until most windows are categorized
-   - Run analysis periodically (daily/weekly) to track trends
+If you prefer a MM:SS formatted column instead, that can be added as an option.
 
 ---
 
-## ⚙️ Configuration
+## Configuration (appsettings.json)
 
-The `appsettings.json` file controls how window titles are classified.
-
-### Configuration File Structure
+Control how window titles map to logical application names and categories. Minimal structure:
 
 ```json
 {
@@ -294,310 +98,38 @@ The `appsettings.json` file controls how window titles are classified.
 }
 ```
 
-### Applications Section
+Tips:
 
-Define how window titles map to logical application names.
+- Put the most specific rules first — matching is "first win".
+- Use executable names (`devenv.exe`, `chrome.exe`) for precise matches.
 
-**Properties:**
+---
 
-- `name` - Logical application name (appears in report)
-- `include` - Keywords that **must all** appear in the window title
-- `exclude` - Keywords that **must not** appear (optional)
+## Commands you’ll use frequently
 
-**Example:**
+Generate the default packaged report:
 
-```json
-{
-  "name": "Browser",
-  "include": [ "Firefox" ],
-  "exclude": [ "taskbeat" ]
-}
+```powershell
+dotnet run --project WindowAnalyser/WindowAnalyser.csproj -- CompleteApp/WindowLogger.csv CompleteApp/Report.xlsx
 ```
 
-**Matching Rules:**
+Publish the tray and GUI into `CompleteApp` (for distribution):
 
-- All `include` keywords must be present (AND logic)
-- Any `exclude` keyword disqualifies the match
-- Matching is **case-insensitive**
-- **First match wins** - order matters!
-
-**Best Practices:**
-
-1. **Specific rules first, generic rules last:**
-```json
-{
-  "applications": [
-    {
-      "name": "Notepad - MyTask",
-      "include": [ "Notepad", "MyTask.txt" ],
-      "exclude": []
-    },
-    {
-      "name": "Notepad",
-      "include": [ "Notepad" ],
-      "exclude": [ "MyTask.txt" ]
-    }
-  ]
-}
-```
-
-2. **Use executable names for precision:**
-```json
-{
-  "name": "Visual Studio",
-  "include": [ "Visual Studio", "devenv.exe" ],
-  "exclude": []
-}
-```
-
-3. **Group similar browsers:**
-```json
-[
-  {
-    "name": "Browser",
-    "include": [ "Firefox" ],
-    "exclude": []
-  },
-  {
-    "name": "Browser",
-    "include": [ "Chrome" ],
-    "exclude": []
-  },
-  {
-    "name": "Browser",
-    "include": [ "Edge" ],
-    "exclude": []
-  }
-]
-```
-
-### Exclusions Section
-
-Define window titles to **completely remove** from analysis.
-
-**Example:**
-```json
-{
-  "exclusions": [
-    {
-      "include": [ "Firefox", "ebay", "cart" ]
-    },
-    {
-      "include": [ "private", "browsing" ]
-    }
-  ]
-}
-```
-
-When a window matches an exclusion rule:
-
-- It's removed from **all** reports
-- Time is not counted anywhere
-- It's as if the window never existed
-
-**Use Cases:**
-
-- Exclude personal browsing during work hours
-- Filter out sensitive/private windows
-- Remove testing/debugging windows
-
-### Categories Section
-
-Group applications into higher-level categories for aggregate reporting.
-
-**Properties:**
-
-- `name` - Category name (appears in report)
-- `includeApplications` - Application names to include
-- `excludeApplications` - Applications to exclude (optional)
-
-**Example:**
-```json
-{
-  "categories": [
-    {
-      "name": "Development",
-      "includeApplications": [ "Visual Studio", "VS Code", "Terminal" ],
-      "excludeApplications": []
-    },
-    {
-      "name": "Productivity",
-      "includeApplications": [ "Notepad", "TaskBeat" ],
-      "excludeApplications": [ "Notepad - MyTask" ]
-    },
-    {
-      "name": "Communication",
-      "includeApplications": [ "Slack", "Teams", "Outlook" ],
-      "excludeApplications": []
-    }
-  ]
-}
-```
-
-**Important:**
-
-- Applications can belong to **multiple categories**
-- Time is counted separately for each category (can exceed 100%)
-- Use `excludeApplications` to create exceptions within broader groups
-
-### Complete Example Configuration
-
-```json
-{
-  "applications": [
-    {
-      "name": "Visual Studio",
-      "include": [ "Visual Studio" ],
-      "exclude": []
-    },
-    {
-      "name": "VS Code",
-      "include": [ "Visual Studio Code" ],
-      "exclude": []
-    },
-    {
-      "name": "Browser",
-      "include": [ "Firefox" ],
-      "exclude": [ "taskbeat" ]
-    },
-    {
-      "name": "TaskBeat",
-      "include": [ "Firefox", "taskbeat" ],
-      "exclude": []
-    },
-    {
-      "name": "Slack",
-      "include": [ "Slack" ],
-      "exclude": []
-    },
-    {
-      "name": "Notepad - MyTask",
-      "include": [ "Notepad", "MyTask.txt" ],
-      "exclude": []
-    },
-    {
-      "name": "Notepad",
-      "include": [ "Notepad" ],
-      "exclude": [ "MyTask.txt" ]
-    }
-  ],
-  "exclusions": [
-    {
-      "include": [ "Firefox", "ebay", "cart" ]
-    }
-  ],
-  "categories": [
-    {
-      "name": "Development",
-      "includeApplications": [ "Visual Studio", "VS Code" ],
-      "excludeApplications": []
-    },
-    {
-      "name": "Communication",
-      "includeApplications": [ "Slack" ],
-      "excludeApplications": []
-    },
-    {
-      "name": "Productivity",
-      "includeApplications": [ "Notepad", "TaskBeat" ],
-      "excludeApplications": [ "Notepad - MyTask" ]
-    },
-    {
-      "name": "MyTask",
-      "includeApplications": [ "Notepad - MyTask" ],
-      "excludeApplications": []
-    }
-  ]
-}
+```powershell
+dotnet publish WindowLoggerTray/WindowLoggerTray.csproj -c Release -o CompleteApp
+dotnet publish WindowLoggerConfigGui/WindowLoggerConfigGui.csproj -c Release -o CompleteApp
 ```
 
 ---
 
-## 🔧 Requirements
+## Troubleshooting
 
-- **Operating System**: Windows (uses Win32 APIs for window tracking)
-- **.NET Runtime**: .NET 9.0 or higher
-- **Excel Viewer**: Microsoft Excel or compatible spreadsheet application
-
-### Dependencies
-
-**WindowLogger:**
-
-- No external dependencies (uses built-in Windows APIs)
-
-**WindowAnalyser:**
-
-- ClosedXML (0.105.0-rc) - for Excel generation
-- Newtonsoft.Json (13.0.3) - for configuration parsing
+- "Error reading appsettings.json": check `appsettings.json` exists and is valid JSON; the analyzer will fall back to defaults if missing.
+- "Report.xlsx locked": close the file in Excel before regenerating — the analyzer overwrites the output file.
+- CSV format error: ensure each row contains at least `Timestamp,Window Title,Status`.
 
 ---
 
-## 📝 Tips & Best Practices
-
-### Data Collection
-
-1. **Run Continuously**: Leave WindowLogger running all day for accurate tracking
-2. **Regular Analysis**: Analyze logs daily or weekly to identify patterns
-3. **Backup Logs**: Copy CSV files regularly - they contain your complete history
-4. **Multiple Logs**: Create separate logs for different projects or time periods by moving/renaming the CSV file
-
-### Configuration
-
-1. **Start Simple**: Begin with broad application categories
-2. **Refine Gradually**: Add more specific rules as you identify patterns
-3. **Use Undefined Tab**: Regularly check "Undefined Applications" to find unmatched windows
-4. **Test Rules**: Re-run analysis after configuration changes to verify rules work as expected
-5. **Document Rules**: Add comments (not supported in JSON, but keep notes separately) about why specific rules exist
-
-### Analysis
-
-1. **Compare Periods**: Generate reports for different time periods to track changes
-2. **Focus on Active Time**: Filter by "Active" status to see productive time
-3. **Review Inactive Patterns**: High inactive time may indicate distractions or away-from-desk time
-4. **Category Overlaps**: Remember that categories can overlap - total category time may exceed 100%
-
----
-
-## 🛠️ Troubleshooting
-
-### "Error reading appsettings.json"
-
-**Cause:** Configuration file is missing or has invalid JSON  
-**Solution:**
-
-1. Ensure `appsettings.json` exists in the same directory as `WindowAnalyser.exe`
-2. Validate JSON syntax using a JSON validator
-3. The analyzer will use default settings (no grouping) if the file is invalid
-
-### "CSV format error: each row must have at least 3 columns"
-
-**Cause:** Log file is corrupted or has an unexpected format  
-**Solution:**
-
-1. Check that the CSV file was created by WindowLogger
-2. Ensure the file hasn't been manually edited with incorrect formatting
-3. Verify the file isn't empty
-
-### No data in Categories or Applications tabs
-
-**Cause:** No windows matched your application rules  
-**Solution:**
-
-1. Check the "Undefined Applications" tab to see what windows were logged
-2. Add application rules to `appsettings.json` matching those window titles
-3. Re-run the analysis
-
-### Log file grows too large
-
-**Cause:** Running continuously for extended periods  
-**Solution:**
-
-1. Archive old logs regularly (e.g., monthly)
-2. Analyze and move the CSV file to a different location
-3. WindowLogger will create a new `window_log.csv` automatically
-
----
-
-## 📄 License
+## License
 
 This project is open source and available under the repository license.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The system runs discretely in the system tray and consists of four components:
 
 ---
 
-## Quick Start (DLL Mode)
+## Quick Start
 
 ### Step 1: Build 
 
@@ -45,7 +45,7 @@ dotnet run
 
 - The logger starts monitoring your active windows every 100ms
 - Console displays each window change
-- Data is saved to `window_log.csv` in the same directory as the executable
+- Data is saved to `WindowLogger.csv` in the same directory as the executable
 - Press **Enter** to stop logging
 
 ### Step 3: Run the Controller
@@ -240,10 +240,10 @@ WindowAnalyser.exe <input-csv-file> <output-xlsx-file>
 
 ```bash
 # Absolute paths
-WindowAnalyser.exe C:\Logs\window_log.csv C:\Reports\weekly_report.xlsx
+WindowAnalyser.exe C:\Logs\WindowLogger.csv C:\Reports\weekly_report.xlsx
 
 # Relative paths
-WindowAnalyser.exe window_log.csv report.xlsx
+WindowAnalyser.exe WindowLogger.csv report.xlsx
 
 # Analyze multiple periods
 WindowAnalyser.exe logs\january.csv reports\january_analysis.xlsx
@@ -293,7 +293,7 @@ Daily breakdown of all window activity
 
 1. **First Run** - Without `appsettings.json`
    ```bash
-   WindowAnalyser.exe window_log.csv initial_report.xlsx
+   WindowAnalyser.exe WindowLogger.csv initial_report.xlsx
    ```
    - All windows appear in "Undefined Applications" tab
    - No categories are generated
@@ -310,7 +310,7 @@ Daily breakdown of all window activity
 
 4. **Re-run Analysis**
    ```bash
-   WindowAnalyser.exe window_log.csv categorized_report.xlsx
+   WindowAnalyser.exe WindowLogger.csv categorized_report.xlsx
    ```
    - Applications now appear in "Applications" tab
    - Categories are populated
@@ -636,7 +636,7 @@ Group applications into higher-level categories for aggregate reporting.
 
 1. Archive old logs regularly (e.g., monthly)
 2. Analyze and move the CSV file to a different location
-3. WindowLogger will create a new `window_log.csv` automatically
+3. WindowLogger will create a new `WindowLogger.csv` automatically
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dotnet run
 - Data is saved to `WindowLogger.csv` in the same directory as the executable
 - Press **Enter** to stop logging
 
-### Step 3: Run the Controller
+### Alternative Step 2: Run the Controller and run the Logger
 
 Navigate to the Tray application's output directory and launch the executable.
 
@@ -84,7 +84,7 @@ Once **WindowLoggerTray** is running, right-click the tray icon to access the me
     - **JSON**: Opens the raw `appsettings.json` file.
 - **Clear Collected Data**: Deletes the current log file to start fresh.
 
-### Step 4: Analyze the Data
+### Step 3: Analyze the Data
 
 Navigate to the WindowAnalyser output directory and run:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ dotnet build WindowLogger.sln
 Navigate to the WindowLogger output directory and run:
 
 ```bash
-cd WindowLogger/bin/Debug/net9.0
+cd WindowLogger/bin/Debug/net10.0
 WindowLogger.exe
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,17 +17,38 @@ The system runs discretely in the system tray and consists of four components:
 
 ## Quick Start (DLL Mode)
 
-Since the application is designed to run as platform-independent .NET binaries (DLLs), the best way to start is to publish the solution.
+### Step 1: Build 
 
-### Step 1: Build and Publish
-
-Run the following command in the solution directory to compile all components into a single folder (e.g., App). The flag `/p:UseAppHost=false` ensures that only DLL files are created, keeping the output clean.
+Build both applications using Visual Studio or the .NET CLI:
 
 ```bash
-dotnet publish -c Release -o ./App /p:UseAppHost=false
+dotnet build WindowLogger.sln
 ```
 
-### Step 2: Run the Controller
+### Step 2: Run the Logger
+
+Navigate to the WindowLogger output directory and run:
+
+```bash
+cd WindowLogger/bin/Debug/net9.0
+WindowLogger.exe
+```
+
+Or from the project directory:
+
+```bash
+cd WindowLogger
+dotnet run
+```
+
+**What happens:**
+
+- The logger starts monitoring your active windows every 100ms
+- Console displays each window change
+- Data is saved to `window_log.csv` in the same directory as the executable
+- Press **Enter** to stop logging
+
+### Step 3: Run the Controller
 
 Navigate to the created folder and start the tray application using the dotnet runtime:
 
@@ -40,8 +61,6 @@ dotnet WindowLoggerTray.dll
 - An icon appears in your System Tray (near the clock).
 - Right-click the icon to control the application.
 
----
-
 ## Using the Controller
 
 Once WindowLoggerTray is running, right-click the tray icon to access the menu:
@@ -53,6 +72,28 @@ Once WindowLoggerTray is running, right-click the tray icon to access the menu:
     - **GUI**: Opens the visual editor (WindowLoggerConfigGui.dll).
     - **JSON**: Opens the raw appsettings.json file.
 - **Clear Collected Data**: Deletes the current log file to start fresh.
+
+### Step 3: Analyze the Data
+
+Navigate to the WindowAnalyser output directory and run:
+
+```bash
+cd WindowAnalyser/bin/Debug/net9.0
+WindowAnalyser.exe WindowLogger.csv output.xlsx
+```
+
+Or from the project directory:
+
+```bash
+cd WindowAnalyser
+dotnet run -- <path-to-csv> <output-xlsx-path>
+```
+
+**Example:**
+
+```bash
+dotnet run -- ../../WindowLogger/bin/Debug/net9.0/WindowLogger.csv weekly_report.xlsx
+```
 
 ---
 

--- a/WindowAnalyser/Program.cs
+++ b/WindowAnalyser/Program.cs
@@ -135,7 +135,8 @@ internal static class Program
                 Date = g.Key.Date,
                 Application = g.Key.App,
                 Status = g.Key.Status,
-                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x.Duration).ToList())
+                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x.Duration).ToList()),
+                TimeSpentSeconds = CalculateTimeSpentSeconds(g.Select(x => x.Duration).ToList())
             })
             .OrderBy(x => x.Date)
             .ThenByDescending(x => x.TimeSpentMinutes);
@@ -164,7 +165,8 @@ internal static class Program
             {
                 Application = g.Key.AppName,
                 Status = g.Key.Status,
-                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x!.Duration).ToList())
+                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x!.Duration).ToList()),
+                TimeSpentSeconds = CalculateTimeSpentSeconds(g.Select(x => x!.Duration).ToList())
             })
             .OrderByDescending(x => x.TimeSpentMinutes)
             .ToList();
@@ -176,7 +178,8 @@ internal static class Program
             {
                 Category = g.Key.Category,
                 Status = g.Key.Status,
-                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x.Duration).ToList())
+                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x.Duration).ToList()),
+                TimeSpentSeconds = CalculateTimeSpentSeconds(g.Select(x => x.Duration).ToList())
             })
             .OrderByDescending(x => x.TimeSpentMinutes)
             .ToList();
@@ -202,17 +205,18 @@ internal static class Program
             {
                 Window = g.Key.WindowTitle,
                 Status = g.Key.Status,
-                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x!.Duration).ToList())
+                TimeSpentMinutes = CalculateTimeSpent(g.Select(x => x!.Duration).ToList()),
+                TimeSpentSeconds = CalculateTimeSpentSeconds(g.Select(x => x!.Duration).ToList())
             })
             .OrderByDescending(x => x.TimeSpentMinutes)
             .ToList();
 
         using (XLWorkbook workbook = new XLWorkbook())
         {
-            WriteWorksheet(workbook, "Categories", groupedCategories.Select(x => new object[] { x.Category, x.Status, x.TimeSpentMinutes, Math.Round(x.TimeSpentMinutes / 60.0, 2) }));
-            WriteWorksheet(workbook, "Applications", groupedApps.Select(x => new object[] { x.Application, x.Status, x.TimeSpentMinutes, Math.Round(x.TimeSpentMinutes / 60.0, 2) }));
-            WriteWorksheet(workbook, "Undefined Applications", otherWindows.Select(x => new object[] { x.Window, x.Status, x.TimeSpentMinutes, Math.Round(x.TimeSpentMinutes / 60.0, 2) }));
-            WriteWorksheet(workbook, "Windows", dailyAppUsage.Select(x => new object[] { x.Date, x.Application, x.Status, x.TimeSpentMinutes, Math.Round(x.TimeSpentMinutes / 60.0, 2) }), true);
+            WriteWorksheet(workbook, "Categories", groupedCategories.Select(x => new object[] { x.Category, x.Status, Math.Round(x.TimeSpentMinutes / 60.0, 2), x.TimeSpentMinutes, x.TimeSpentSeconds }));
+            WriteWorksheet(workbook, "Applications", groupedApps.Select(x => new object[] { x.Application, x.Status, Math.Round(x.TimeSpentMinutes / 60.0, 2), x.TimeSpentMinutes, x.TimeSpentSeconds }));
+            WriteWorksheet(workbook, "Undefined Applications", otherWindows.Select(x => new object[] { x.Window, x.Status, Math.Round(x.TimeSpentMinutes / 60.0, 2), x.TimeSpentMinutes, x.TimeSpentSeconds }));
+            WriteWorksheet(workbook, "Windows", dailyAppUsage.Select(x => new object[] { x.Date, x.Application, x.Status, Math.Round(x.TimeSpentMinutes / 60.0, 2), x.TimeSpentMinutes, x.TimeSpentSeconds }), true);
             workbook.SaveAs(outputFile);
         }
 
@@ -275,43 +279,83 @@ internal static class Program
         double totalMinutes = timestamps.Sum(t => t.TotalMinutes);
         return Math.Round(totalMinutes, 2);
     }
+    private static int CalculateTimeSpentSeconds(List<TimeSpan> timestamps)
+    {
+        if (timestamps == null || timestamps.Count == 0)
+            return 0;
+
+        double totalSeconds = timestamps.Sum(t => t.TotalSeconds);
+        return (int)Math.Round(totalSeconds, 0);
+    }
     private static void WriteWorksheet(XLWorkbook workbook, string sheetName, IEnumerable<object[]> rows, bool DisplayDate = false)
     {
         IXLWorksheet worksheet = workbook.Worksheets.Add(sheetName);
 
         int dateCol = 0;
-        if(DisplayDate)
+        if (DisplayDate)
         {
             worksheet.Cell(1, 1).Value = "Date";
             dateCol = 1;
         }
 
+        // Determine header base position after optional Date column
+        int baseCol = 1 + dateCol;
+
         if (sheetName.Contains("Category"))
         {
-            worksheet.Cell(1, 1 + dateCol).Value = sheetName.Contains("Window") ? "Window" : "Category";
+            worksheet.Cell(1, baseCol).Value = sheetName.Contains("Window") ? "Window" : "Category";
         }
         else
         {
-            worksheet.Cell(1, 1 + dateCol).Value = sheetName.Contains("Window") ? "Window" : "Application";
+            worksheet.Cell(1, baseCol).Value = sheetName.Contains("Window") ? "Window" : "Application";
         }
 
-        worksheet.Cell(1, 2 + dateCol).Value = "Status";
-        worksheet.Cell(1, 3 + dateCol).Value = "Time Spent (Minutes)";
-        worksheet.Cell(1, 4 + dateCol).Value = "Time Spent (Hours)";
+        worksheet.Cell(1, baseCol + 1).Value = "Status";
+
+        // Inspect rows to decide how many time columns are present
+        var firstRow = rows.FirstOrDefault();
+        int dataCols = firstRow != null ? firstRow.Length : 4; // fallback
+
+        // Expect time columns in order: Hours, Minutes, Seconds (Seconds optional)
+        worksheet.Cell(1, baseCol + 2).Value = "Time Spent (Hours)";
+        worksheet.Cell(1, baseCol + 3).Value = "Time Spent (Minutes)";
+        if (dataCols >= 5)
+        {
+            worksheet.Cell(1, baseCol + 4).Value = "Time Spent (Seconds)";
+        }
 
         int row = 2;
         foreach (object[] dataRow in rows)
         {
             for (int col = 0; col < dataRow.Length; col++)
             {
-                if (dataRow[col] is double)
-                    worksheet.Cell(row, col + 1).Value = Math.Round((double)dataRow[col], 2);
-                else worksheet.Cell(row, col + 1).Value = dataRow[col] is DateTime ? (XLCellValue)((DateTime)dataRow[col]).ToString("yyyy-MM-dd") : (XLCellValue)dataRow[col].ToString();
+                var value = dataRow[col];
+                int colIndex = col + 1; // data rows already include Date when DisplayDate=true
+                if (value is double d)
+                {
+                    worksheet.Cell(row, colIndex).Value = Math.Round(d, 2);
+                }
+                else if (value is int i)
+                {
+                    worksheet.Cell(row, colIndex).Value = i;
+                }
+                else if (value is long l)
+                {
+                    worksheet.Cell(row, colIndex).Value = l;
+                }
+                else if (value is DateTime dt)
+                {
+                    worksheet.Cell(row, colIndex).Value = dt.ToString("yyyy-MM-dd");
+                }
+                else
+                {
+                    worksheet.Cell(row, colIndex).Value = value?.ToString() ?? string.Empty;
+                }
             }
             row++;
         }
 
-        IXLRange range = worksheet.Range(1, 1, row - 1, 4 + +dateCol);
+        IXLRange range = worksheet.Range(1, 1, row - 1, baseCol + dataCols - 1);
         range.Style.Border.OutsideBorder = XLBorderStyleValues.Thin;
         range.Style.Border.InsideBorder = XLBorderStyleValues.Thin;
         worksheet.Columns().AdjustToContents();

--- a/WindowLogger.sln
+++ b/WindowLogger.sln
@@ -14,24 +14,66 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WindowLoggerTray", "WindowLoggerTray\WindowLoggerTray.csproj", "{58D41FEC-9218-47C0-9A55-B1981A897EF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Debug|x64.Build.0 = Debug|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Debug|x86.Build.0 = Debug|Any CPU
 		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Release|x64.ActiveCfg = Release|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Release|x64.Build.0 = Release|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Release|x86.ActiveCfg = Release|Any CPU
+		{B33F7DFE-C8DB-4332-B890-DCC419A2ED12}.Release|x86.Build.0 = Release|Any CPU
 		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Debug|x64.Build.0 = Debug|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Debug|x86.Build.0 = Debug|Any CPU
 		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Release|x64.ActiveCfg = Release|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Release|x64.Build.0 = Release|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Release|x86.ActiveCfg = Release|Any CPU
+		{F049A38C-30B5-431A-AA8A-6AD35951C8C4}.Release|x86.Build.0 = Release|Any CPU
 		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Debug|x64.Build.0 = Debug|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Debug|x86.Build.0 = Debug|Any CPU
 		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Release|x64.ActiveCfg = Release|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Release|x64.Build.0 = Release|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Release|x86.ActiveCfg = Release|Any CPU
+		{7BDE77BB-CEAF-4445-B869-117118BCA82B}.Release|x86.Build.0 = Release|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Debug|x64.Build.0 = Debug|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Debug|x86.Build.0 = Debug|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Release|x64.ActiveCfg = Release|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Release|x64.Build.0 = Release|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Release|x86.ActiveCfg = Release|Any CPU
+		{58D41FEC-9218-47C0-9A55-B1981A897EF2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WindowLogger/Program.cs
+++ b/WindowLogger/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Timers;
@@ -30,8 +30,8 @@ internal static class Program
     {
         Console.WriteLine("Active window logger started.");
         
-        // Initialize StreamWriter with AutoFlush enabled
-        _logWriter = new StreamWriter(LogFileName, append: true, Encoding.UTF8)
+        string logPath = Path.Combine(AppContext.BaseDirectory, LogFileName);
+        _logWriter = new StreamWriter(logPath, append: true, Encoding.UTF8)
         {
             AutoFlush = true
         };

--- a/WindowLogger/Program.cs
+++ b/WindowLogger/Program.cs
@@ -31,10 +31,18 @@ internal static class Program
         Console.WriteLine("Active window logger started.");
         
         string logPath = Path.Combine(AppContext.BaseDirectory, LogFileName);
+
+        bool writeHeader = !File.Exists(logPath) || new FileInfo(logPath).Length == 0;
         _logWriter = new StreamWriter(logPath, append: true, Encoding.UTF8)
         {
             AutoFlush = true
         };
+
+        if (writeHeader)
+        {
+            _logWriter.WriteLine("Timestamp,WindowTitle,Status");
+            _logWriter.Flush();
+        }
         
         _timer = new Timer(100); 
         _timer.Elapsed += TimerElapsed;

--- a/WindowLoggerTray/Program.cs
+++ b/WindowLoggerTray/Program.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Windows.Forms;
+
+namespace WindowLoggerTray;
+
+static class Program
+{
+    [STAThread]
+    static void Main()
+    {
+        Application.SetHighDpiMode(HighDpiMode.SystemAware);
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+
+        // Launching the app while using out context instead of Form
+        Application.Run(new TrayApplicationContext());
+    }
+}

--- a/WindowLoggerTray/TrayApplicationContext.cs
+++ b/WindowLoggerTray/TrayApplicationContext.cs
@@ -1,0 +1,253 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace WindowLoggerTray;
+
+public class TrayApplicationContext : ApplicationContext
+{
+    private readonly NotifyIcon _notifyIcon;
+    private Process? _loggerProcess;
+    
+    // Executable names (located in application directory)
+    private const string LoggerExe = "WindowLogger.exe";
+    private const string AnalyserExe = "WindowAnalyser.exe";
+    private const string ConfigGuiExe = "WindowLoggerConfigGui.exe";
+    private const string ConfigFile = "appsettings.json";
+    private const string LogFile = "WindowLogger.csv";
+    private const string ReportFile = "Report.xlsx";
+
+    // Menu items
+    private ToolStripMenuItem _startLoggingItem = null!;
+    private ToolStripMenuItem _stopLoggingItem = null!;
+
+    public TrayApplicationContext()
+    {
+        _notifyIcon = new NotifyIcon
+        {
+            // Use the application icon; replace with a custom .ico if desired
+            Icon = SystemIcons.Application, 
+            Visible = true,
+            Text = "Window Logger Controller"
+        };
+
+        _notifyIcon.ContextMenuStrip = CreateContextMenu();
+        
+        // Check if the logger process is already running
+        CheckExistingProcess();
+    }
+
+    private ContextMenuStrip CreateContextMenu()
+    {
+        var menu = new ContextMenuStrip();
+
+        // Logger control
+        _startLoggingItem = new ToolStripMenuItem("Start Logging", null, (s, e) => StartLogger());
+        _stopLoggingItem = new ToolStripMenuItem("Stop Logging", null, (s, e) => StopLogger());
+        
+        menu.Items.Add(_startLoggingItem);
+        menu.Items.Add(_stopLoggingItem);
+        menu.Items.Add(new ToolStripSeparator());
+
+        // Analysis
+        menu.Items.Add("Generate Report & Open", null, (s, e) => RunAnalysis());
+        menu.Items.Add(new ToolStripSeparator());
+
+        // Configuration
+        menu.Items.Add("Edit Configuration (GUI)", null, (s, e) => OpenConfigGui());
+        menu.Items.Add("Edit Configuration (JSON)", null, (s, e) => OpenConfigJson());
+        
+        // Data
+        var clearDataMenu = new ToolStripMenuItem("Clear Collected Data");
+        clearDataMenu.Click += (s, e) => ClearData();
+        menu.Items.Add(clearDataMenu);
+        
+        menu.Items.Add(new ToolStripSeparator());
+
+        // Exit
+        menu.Items.Add("Exit", null, (s, e) => Exit());
+
+        UpdateMenuState();
+        return menu;
+    }
+
+    private void StartLogger()
+    {
+        if (_loggerProcess != null && !_loggerProcess.HasExited) return;
+
+        if (!File.Exists(LoggerExe))
+        {
+            ShowError($"Could not find {LoggerExe} in the application directory.\nPath: {AppDomain.CurrentDomain.BaseDirectory}");
+            return;
+        }
+
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = LoggerExe,
+                UseShellExecute = false,
+                CreateNoWindow = true, // Run with a hidden console window
+                WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory
+            };
+
+            _loggerProcess = Process.Start(startInfo);
+            _notifyIcon.ShowBalloonTip(3000, "Window Logger", "Logging started in background.", ToolTipIcon.Info);
+        }
+        catch (Exception ex)
+        {
+            ShowError($"Failed to start logger: {ex.Message}");
+        }
+
+        UpdateMenuState();
+    }
+
+    private void StopLogger()
+    {
+        if (_loggerProcess == null || _loggerProcess.HasExited) return;
+
+        try
+        {
+            // Terminate the process; logger flushes output on exit.
+            _loggerProcess.Kill();
+            _loggerProcess.WaitForExit(1000);
+            _loggerProcess = null;
+            _notifyIcon.ShowBalloonTip(3000, "Window Logger", "Logging stopped.", ToolTipIcon.Info);
+        }
+        catch (Exception ex)
+        {
+            ShowError($"Failed to stop logger: {ex.Message}");
+        }
+
+        UpdateMenuState();
+    }
+
+    private void RunAnalysis()
+    {
+        if (!File.Exists(AnalyserExe))
+        {
+            ShowError($"{AnalyserExe} not found.");
+            return;
+        }
+
+        if (!File.Exists(LogFile))
+        {
+            ShowError("No log file found to analyze. Please run the logger first.");
+            return;
+        }
+
+        try
+        {
+            // Run analyzer and open the generated report
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = AnalyserExe,
+                Arguments = $"\"{LogFile}\" \"{ReportFile}\"",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory
+            };
+
+            var process = Process.Start(startInfo);
+            process?.WaitForExit();
+
+            // Open the generated report
+            if (File.Exists(ReportFile))
+            {
+                new Process
+                {
+                    StartInfo = new ProcessStartInfo(ReportFile) { UseShellExecute = true }
+                }.Start();
+            }
+            else
+            {
+                ShowError("Report file was not created. Check if the log file is empty.");
+            }
+        }
+        catch (Exception ex)
+        {
+            ShowError($"Analysis failed: {ex.Message}");
+        }
+    }
+
+    private void OpenConfigGui()
+    {
+        if (File.Exists(ConfigGuiExe))
+        {
+            Process.Start(new ProcessStartInfo(ConfigGuiExe) { UseShellExecute = true });
+        }
+        else
+        {
+            ShowError($"{ConfigGuiExe} not found.");
+        }
+    }
+
+    private void OpenConfigJson()
+    {
+        if (File.Exists(ConfigFile))
+        {
+            // Open in the default JSON/text editor
+            Process.Start(new ProcessStartInfo(ConfigFile) { UseShellExecute = true });
+        }
+        else
+        {
+            ShowError($"{ConfigFile} not found. Run the analyzer to generate a default file or create it manually.");
+        }
+    }
+
+    private void ClearData()
+    {
+        if (MessageBox.Show("Are you sure you want to delete the log file? This cannot be undone.", 
+            "Clear Data", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == DialogResult.Yes)
+        {
+            try
+            {
+                bool wasRunning = _loggerProcess != null && !_loggerProcess.HasExited;
+                if (wasRunning) StopLogger();
+
+                if (File.Exists(LogFile)) File.Delete(LogFile);
+
+                if (wasRunning) StartLogger();
+                
+                _notifyIcon.ShowBalloonTip(3000, "Data Cleared", "Log file has been deleted.", ToolTipIcon.Info);
+            }
+            catch (Exception ex)
+            {
+                ShowError($"Failed to clear data: {ex.Message}");
+            }
+        }
+    }
+
+    private void CheckExistingProcess()
+    {
+        // Detect any running logger process by name
+        var existing = Process.GetProcessesByName(Path.GetFileNameWithoutExtension(LoggerExe));
+        if (existing.Length > 0)
+        {
+            _loggerProcess = existing[0];
+        }
+        UpdateMenuState();
+    }
+
+    private void UpdateMenuState()
+    {
+        bool isRunning = _loggerProcess != null && !_loggerProcess.HasExited;
+        _startLoggingItem.Enabled = !isRunning;
+        _stopLoggingItem.Enabled = isRunning;
+    }
+
+    private void ShowError(string message)
+    {
+        MessageBox.Show(message, "Window Logger Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+    }
+
+    private void Exit()
+    {
+        // Stop logger on exit
+        if (_loggerProcess != null && !_loggerProcess.HasExited)
+        {
+            StopLogger();
+        }
+        _notifyIcon.Visible = false;
+        Application.Exit();
+    }
+}

--- a/WindowLoggerTray/TrayApplicationContext.cs
+++ b/WindowLoggerTray/TrayApplicationContext.cs
@@ -271,4 +271,3 @@ public class TrayApplicationContext : ApplicationContext
     }
 }
 
-}

--- a/WindowLoggerTray/TrayApplicationContext.cs
+++ b/WindowLoggerTray/TrayApplicationContext.cs
@@ -100,8 +100,7 @@ public class TrayApplicationContext : ApplicationContext
                 FileName = LoggerExe,
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                // IMPORTANT: Do not force WorkingDirectory. Let the Logger run in its own folder.
-                // This ensures the CSV is created next to the Logger executable.
+                WorkingDirectory = Path.GetDirectoryName(LoggerExe)
             };
 
             _loggerProcess = Process.Start(startInfo);

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>WindowLoggerTray.Program</StartupObject>
-    <UseAppHost>false</UseAppHost> 
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,5 +18,16 @@
     <ProjectReference Include="..\WindowAnalyser\WindowAnalyser.csproj" />
     <ProjectReference Include="..\WindowLoggerConfigGui\WindowLoggerConfigGui.csproj" />
   </ItemGroup>
+
+  <Target Name="CopyExecutables" AfterTargets="Build">
+    <Copy SourceFiles="..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe" 
+          DestinationFolder="$(OutDir)" />
+    
+    <Copy SourceFiles="..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.exe" 
+          DestinationFolder="$(OutDir)" />
+    
+    <Copy SourceFiles="..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe" 
+          DestinationFolder="$(OutDir)" />
+  </Target>
 
 </Project>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -7,10 +7,17 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <StartupObject>WindowLoggerTray.Program</StartupObject>
+    <UseAppHost>false</UseAppHost> 
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WindowLogger\WindowLogger.csproj" />
+    <ProjectReference Include="..\WindowAnalyser\WindowAnalyser.csproj" />
+    <ProjectReference Include="..\WindowLoggerConfigGui\WindowLoggerConfigGui.csproj" />
   </ItemGroup>
 
 </Project>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -21,16 +21,22 @@
 
   <Target Name="CopyExecutables" AfterTargets="Build">
     <Copy SourceFiles="..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe" 
+          DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.runtimeconfig.json" 
           DestinationFolder="$(OutDir)" 
-          Condition="Exists('..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe')" />
+          Condition="Exists('..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.runtimeconfig.json')" />
 
     <Copy SourceFiles="..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.exe" 
+          DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.runtimeconfig.json" 
           DestinationFolder="$(OutDir)" 
-          Condition="Exists('..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.exe')" />
+          Condition="Exists('..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.runtimeconfig.json')" />
 
     <Copy SourceFiles="..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe" 
+          DestinationFolder="$(OutDir)" />
+    <Copy SourceFiles="..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe.config" 
           DestinationFolder="$(OutDir)" 
-          Condition="Exists('..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe')" />
+          Condition="Exists('..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe.config')" />
   </Target>
 
 </Project>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -21,13 +21,16 @@
 
   <Target Name="CopyExecutables" AfterTargets="Build">
     <Copy SourceFiles="..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe" 
-          DestinationFolder="$(OutDir)" />
-    
+          DestinationFolder="$(OutDir)" 
+          Condition="Exists('..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe')" />
+
     <Copy SourceFiles="..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.exe" 
-          DestinationFolder="$(OutDir)" />
-    
+          DestinationFolder="$(OutDir)" 
+          Condition="Exists('..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.exe')" />
+
     <Copy SourceFiles="..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe" 
-          DestinationFolder="$(OutDir)" />
+          DestinationFolder="$(OutDir)" 
+          Condition="Exists('..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe')" />
   </Target>
 
 </Project>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net10.0-windows</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Message Text=">>> KOPIOWANIE PLIKÓW WYKONYWALNYCH DO TRAYA <<<" Importance="high" />
 
     <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe&quot; &quot;$(TargetDir)&quot;" />
     <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.runtimeconfig.json&quot; &quot;$(TargetDir)&quot;" />

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <StartupObject>WindowLoggerTray.Program</StartupObject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/WindowLoggerTray/WindowLoggerTray.csproj
+++ b/WindowLoggerTray/WindowLoggerTray.csproj
@@ -19,24 +19,18 @@
     <ProjectReference Include="..\WindowLoggerConfigGui\WindowLoggerConfigGui.csproj" />
   </ItemGroup>
 
-  <Target Name="CopyExecutables" AfterTargets="Build">
-    <Copy SourceFiles="..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe" 
-          DestinationFolder="$(OutDir)" />
-    <Copy SourceFiles="..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.runtimeconfig.json" 
-          DestinationFolder="$(OutDir)" 
-          Condition="Exists('..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.runtimeconfig.json')" />
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Message Text=">>> KOPIOWANIE PLIKÓW WYKONYWALNYCH DO TRAYA <<<" Importance="high" />
 
-    <Copy SourceFiles="..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.exe" 
-          DestinationFolder="$(OutDir)" />
-    <Copy SourceFiles="..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.runtimeconfig.json" 
-          DestinationFolder="$(OutDir)" 
-          Condition="Exists('..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.runtimeconfig.json')" />
+    <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.exe&quot; &quot;$(TargetDir)&quot;" />
+    <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowLogger\bin\$(Configuration)\net10.0\WindowLogger.runtimeconfig.json&quot; &quot;$(TargetDir)&quot;" />
 
-    <Copy SourceFiles="..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe" 
-          DestinationFolder="$(OutDir)" />
-    <Copy SourceFiles="..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe.config" 
-          DestinationFolder="$(OutDir)" 
-          Condition="Exists('..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe.config')" />
+    <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.exe&quot; &quot;$(TargetDir)&quot;" />
+    <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowAnalyser\bin\$(Configuration)\net10.0\WindowAnalyser.runtimeconfig.json&quot; &quot;$(TargetDir)&quot;" />
+    <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowAnalyser\appsettings.json&quot; &quot;$(TargetDir)&quot;" />
+
+    <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe&quot; &quot;$(TargetDir)&quot;" />
+    <Exec Command="copy /Y &quot;$(ProjectDir)..\WindowLoggerConfigGui\bin\$(Configuration)\net48\WindowLoggerConfigGui.exe.config&quot; &quot;$(TargetDir)&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
This Pull Request introduces significant usability improvements to the WindowLogger ecosystem, primarily by adding a new System Tray Controller application. It also enhances the analysis report with seconds-level precision and streamlines the documentation.
<img width="335" height="207" alt="image" src="https://github.com/user-attachments/assets/93a0219d-aa56-4014-8d8c-4d96fb23bd94" />
Documentation updates: Rewritten README.md - The documentation has been simplified and restructured for better readability; New Quick Start - Updated instructions to recommend dotnet publish and using the Trac Controller instead of running console apps manually.